### PR TITLE
fix to stop IE11 from displaying dialog with null text

### DIFF
--- a/addon/services/navigation-guard.js
+++ b/addon/services/navigation-guard.js
@@ -21,7 +21,7 @@ export default class NavigationGuardService extends Service {
   init() {
     super.init(...arguments);
     emberWindow.onbeforeunload = (e) => {
-      if (!this.preventNav) return null;
+      if (!this.preventNav) return undefined;
       e = e || window.event;
 
       //old browsers


### PR DESCRIPTION
From [onbeforeunload MDN page](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload):

> Internet Explorer does not respect the null return value and will display this to users as "null" text. You have to use undefined to skip the prompt.