### PR TITLE
Revert "Bump eslint-plugin-ember from 11.4.8 to 11.4.9 (#529)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21532,9 +21532,9 @@
       "dev": true
     },
     "node_modules/ember-template-imports": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-3.4.2.tgz",
-      "integrity": "sha512-OS8TUVG2kQYYwP3netunLVfeijPoOKIs1SvPQRTNOQX4Pu8xGGBEZmrv0U1YTnQn12Eg+p6w/0UdGbUnITjyzw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-3.4.1.tgz",
+      "integrity": "sha512-KXnBFTAVxCfXnSCUgd/iuic9ajWbmFkRUBEeorJAMqxvougsPoK22s5ygE9O3GnzYdPpMwn+8v+/NAGy8HRBGA==",
       "dev": true,
       "dependencies": {
         "babel-import-util": "^0.2.0",
@@ -23923,16 +23923,16 @@
       "dev": true
     },
     "node_modules/eslint-plugin-ember": {
-      "version": "11.4.9",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-11.4.9.tgz",
-      "integrity": "sha512-1nAgMSwAJrntfvsiyIyHtYY+AvAPZ1wxcoa+gsui/VviQqULCtZLF8+1UAOTAGJ5bEjhe3f8TTcyRGHXRPHzeQ==",
+      "version": "11.4.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-11.4.8.tgz",
+      "integrity": "sha512-ytHEMDNkXbkBAfw2loR62pLozOiMp+Y7BJaupSQK25lCsfrhVMsfog2uTvicoCwDDPgcOJrivdUmMbfErOGOdQ==",
       "dev": true,
       "dependencies": {
         "@ember-data/rfc395-data": "^0.0.4",
         "@glimmer/syntax": "^0.84.2",
         "css-tree": "^2.0.4",
         "ember-rfc176-data": "^0.3.15",
-        "ember-template-imports": "^3.4.2",
+        "ember-template-imports": "^3.4.1",
         "eslint-utils": "^3.0.0",
         "estraverse": "^5.2.0",
         "lodash.camelcase": "^4.1.1",
@@ -60356,9 +60356,9 @@
       }
     },
     "ember-template-imports": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-3.4.2.tgz",
-      "integrity": "sha512-OS8TUVG2kQYYwP3netunLVfeijPoOKIs1SvPQRTNOQX4Pu8xGGBEZmrv0U1YTnQn12Eg+p6w/0UdGbUnITjyzw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-3.4.1.tgz",
+      "integrity": "sha512-KXnBFTAVxCfXnSCUgd/iuic9ajWbmFkRUBEeorJAMqxvougsPoK22s5ygE9O3GnzYdPpMwn+8v+/NAGy8HRBGA==",
       "dev": true,
       "requires": {
         "babel-import-util": "^0.2.0",
@@ -62410,16 +62410,16 @@
       "dev": true
     },
     "eslint-plugin-ember": {
-      "version": "11.4.9",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-11.4.9.tgz",
-      "integrity": "sha512-1nAgMSwAJrntfvsiyIyHtYY+AvAPZ1wxcoa+gsui/VviQqULCtZLF8+1UAOTAGJ5bEjhe3f8TTcyRGHXRPHzeQ==",
+      "version": "11.4.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-11.4.8.tgz",
+      "integrity": "sha512-ytHEMDNkXbkBAfw2loR62pLozOiMp+Y7BJaupSQK25lCsfrhVMsfog2uTvicoCwDDPgcOJrivdUmMbfErOGOdQ==",
       "dev": true,
       "requires": {
         "@ember-data/rfc395-data": "^0.0.4",
         "@glimmer/syntax": "^0.84.2",
         "css-tree": "^2.0.4",
         "ember-rfc176-data": "^0.3.15",
-        "ember-template-imports": "^3.4.2",
+        "ember-template-imports": "^3.4.1",
         "eslint-utils": "^3.0.0",
         "estraverse": "^5.2.0",
         "lodash.camelcase": "^4.1.1",


### PR DESCRIPTION
This reverts commit 69ba6bb867106df58e963d84e630867b46074f52.